### PR TITLE
Load config to change class name for current

### DIFF
--- a/lib/current_page_helper.js
+++ b/lib/current_page_helper.js
@@ -6,9 +6,14 @@
  * Licensed under the MIT license.
  */
 
+var _ = require("underscore");
 var helper_utils = require("punch").Utils.Helper;
 
 var current_page = "";
+
+var this_config = {
+	classname: "current"
+};
 
 var block_helpers = {
 
@@ -29,7 +34,7 @@ var block_helpers = {
 			}
 
 			if (text.toLowerCase() === current_page) {
-				return "current";
+				return this_config.classname;
 			} else {
 				return "";
 			}
@@ -39,6 +44,11 @@ var block_helpers = {
 };
 
 module.exports = {
+
+	setup: function(config) {
+			var current_page_config = config.current_page;
+			this_config = _.extend(this_config, current_page_config);
+	},
 
 	directAccess: function() {
 		return { "block_helpers": block_helpers, "options": {} };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "main": "lib/current_page_helper",
   "dependencies": {
-    "punch": ">= 0.4.0"
+    "punch": ">= 0.4.0",
+    "underscore": "~1.5.2"
   },
   "devDependencies": {
     "jasmine-node": ">= 1.0.26",


### PR DESCRIPTION
## Ex) Class name for Twitter bootstrap

```
{
    "current_page": {
        "classname": "active"
    },
    "plugins": {
        "helpers": {
            "current_page_helper": "punch-current-page-helper"
        },
        "template_engine": "punch-engine-handlebars"
    }
}
```

I have no idea how to test loading config, so there is no test sorry.
If it really required, I will try.
I'm sure no error rised when key of `current_page` is not exists in config.json
because I ran this code on my project.
